### PR TITLE
Allow content rotation by 90 or 270 degrees

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,17 @@ Use OLED display with the SH1106 driver with SPI or I2C. It is based on the Micr
 framebuffer class and consists wrappers for this class as well as special methods
 for controlling the display.
 
+### 90° Rotation
+
+The `rotate90` parameter in the constructor allows you to rotate the display by 90 degrees.
+However, this comes at a price: Since we will have to it in software, a second, internal framebuffer
+will be created, using an additional `width * height / 8` bytes of RAM. Also, each call to `show()`
+will take about 33% longer.
+
+If you would like to use this feature, keep `width` and `height` in the constructor unchanged, i.e.
+set to the _physical_ dimensions of your display. Also, it is currently not possible to toggle 90°
+rotation on or off dynamically, you will have to make your decision in the constructor.
+
 ## Connection
 
 The SH1106 supports next to thers the I2C or SPI interface. The connection depends on the interface used
@@ -33,18 +44,19 @@ Besides the constructors, the methods are the same.
 
 ### I2C
 ```
-display = sh1106.SH1106_I2C(width, height, i2c, reset, address)
+display = sh1106.SH1106_I2C(width, height, i2c, reset, address, rotate90)
 ```
 - width and height define the size of the display
 - i2c is an I2C object, which has to be created beforehand and tells the ports for SDA and SCL.
 - res is the GPIO Pin object for the reset connection. It will be initialized by the driver.
 If it is not needed, `None` has to be supplied.
 - adr is the I2C address of the display. Default 0x3c or 60
+- rotate90 will rotate the display by 90 degrees, see above. Defaults to `False`.
 
 
 ### SPI
 ```
-display = sh1106.SH1106_SPI(width, height, spi, dc, res, cs)
+display = sh1106.SH1106_SPI(width, height, spi, dc, res, cs, rotate90)
 ```
 - width and height define the size of the display
 - spi is an SPI object, which has to be created beforehand and tells the ports for SCLJ and MOSI.
@@ -56,6 +68,7 @@ of `None` applies.
 - cs is the GPIO Pin object for the CS connection. It will be initialized by the driver.
 If it is not needed, it can be set to `None` or omitted. In this case the default value
 of `None` applies.
+- rotate90 will rotate the display by 90 degrees, see above. Defaults to `False`.
 
 
 ## Methods
@@ -96,14 +109,16 @@ effective for the whole display.
 - flag = True  Invert
 - flag = False Normal mode
 
-###  display.rotate()
+###  display.flip()
 ```
-display.rotate(flag[, update=True])
+display.flip(flag[, update=True])
 ```
-Rotate the content of the display, depending on the value of Flag.
+Rotate the content of the display 180 degrees, depending on the value of Flag.
 To become fully effective, you have to run display.show(). If the parameter update is True, show() is called by the function itself.
 - flag = True: Rotate by 180 degree
-- flag = False: Normal mode  
+- flag = False: Normal mode
+This setting can be combined with the `rotate90` setting in order to rotate the display's contents
+by 270 degrees.
 
 ###  display.show()
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ for controlling the display.
 ### Content Rotation
 
 The `rotate` parameter in the constructor allows you to rotate the display by a 90, 180 or 270
-degrees clockwise. 0 and 180 degrees are easy, because they can be done using hardware flags of the
+degrees clockwise. 180 degrees are easy, because this can be done using only hardware flags of the
 SH1106 display. 90 and 270 degrees however are not. These come at a price: Since we will have to it
 in software, a second, internal framebuffer will be created, using an additional
 `width * height / 8` bytes of RAM. Also, each call to `show()` will take about 33% longer.
@@ -49,19 +49,19 @@ Besides the constructors, the methods are the same.
 
 ### I2C
 ```
-display = sh1106.SH1106_I2C(width, height, i2c, reset, address, rotate90)
+display = sh1106.SH1106_I2C(width, height, i2c, reset, address, rotate=0)
 ```
 - width and height define the size of the display
 - i2c is an I2C object, which has to be created beforehand and tells the ports for SDA and SCL.
 - res is the GPIO Pin object for the reset connection. It will be initialized by the driver.
 If it is not needed, `None` has to be supplied.
 - adr is the I2C address of the display. Default 0x3c or 60
-- rotate90 will rotate the display by 90 degrees, see above. Defaults to `False`.
+- rotate defines display content rotation. See above for details and caveats.
 
 
 ### SPI
 ```
-display = sh1106.SH1106_SPI(width, height, spi, dc, res, cs, rotate90)
+display = sh1106.SH1106_SPI(width, height, spi, dc, res, cs, rotate=0)
 ```
 - width and height define the size of the display
 - spi is an SPI object, which has to be created beforehand and tells the ports for SCLJ and MOSI.
@@ -73,7 +73,7 @@ of `None` applies.
 - cs is the GPIO Pin object for the CS connection. It will be initialized by the driver.
 If it is not needed, it can be set to `None` or omitted. In this case the default value
 of `None` applies.
-- rotate90 will rotate the display by 90 degrees, see above. Defaults to `False`.
+- rotate defines display content rotation. See above for details and caveats.
 
 
 ## Methods

--- a/readme.md
+++ b/readme.md
@@ -10,16 +10,21 @@ Use OLED display with the SH1106 driver with SPI or I2C. It is based on the Micr
 framebuffer class and consists wrappers for this class as well as special methods
 for controlling the display.
 
-### 90° Rotation
+### Content Rotation
 
-The `rotate90` parameter in the constructor allows you to rotate the display by 90 degrees.
-However, this comes at a price: Since we will have to it in software, a second, internal framebuffer
-will be created, using an additional `width * height / 8` bytes of RAM. Also, each call to `show()`
-will take about 33% longer.
+The `rotate` parameter in the constructor allows you to rotate the display by a 90, 180 or 270
+degrees clockwise. 0 and 180 degrees are easy, because they can be done using hardware flags of the
+SH1106 display. 90 and 270 degrees however are not. These come at a price: Since we will have to it
+in software, a second, internal framebuffer will be created, using an additional
+`width * height / 8` bytes of RAM. Also, each call to `show()` will take about 33% longer.
 
-If you would like to use this feature, keep `width` and `height` in the constructor unchanged, i.e.
-set to the _physical_ dimensions of your display. Also, it is currently not possible to toggle 90°
-rotation on or off dynamically, you will have to make your decision in the constructor.
+Set `width` and `height` in the constructor to the _physical_ dimensions of your display, regardless
+of how you would like to rotate it.
+
+You can use the `flip()` method to toggle between 0 and 180 degrees of rotation, or between 90 and
+270 degrees, at runtime, which is equivalent to rotating the contents for 180 degrees compared to
+whatever the rotation was before. It is however not possible to switch from "portrait" to
+"landscape" or vice versa at runtime, because of the additional buffer required.
 
 ## Connection
 
@@ -111,14 +116,16 @@ effective for the whole display.
 
 ###  display.flip()
 ```
-display.flip(flag[, update=True])
+display.flip([flag=None[, update=True]])
 ```
-Rotate the content of the display 180 degrees, depending on the value of Flag.
-To become fully effective, you have to run display.show(). If the parameter update is True, show() is called by the function itself.
-- flag = True: Rotate by 180 degree
-- flag = False: Normal mode
-This setting can be combined with the `rotate90` setting in order to rotate the display's contents
-by 270 degrees.
+Rotate the content of the display an additional 180 degrees, depending on the value of `flag`.
+
+- `True`: If you selected 0 or 90 degrees of rotation in the constructor, rotation will be set to 180 or 270, respectively. Else, it has no effect.
+- `False`: If you selected 180 or 270 degrees of rotation in the constructor, rotation will be set to 0 or 90, respectively. Else, it has no effect.
+- `None`: Toggle flip on or off: 0 degrees will become 180, 90 will become 270, 180 will become 0 and 270 will become 90.
+
+To become fully effective, you have to run `display.show()`. If the parameter `update` is `True`,
+`show()` is called by the function itself.
 
 ###  display.show()
 

--- a/sh1106.py
+++ b/sh1106.py
@@ -87,16 +87,30 @@ _SET_PAGE_ADDRESS    = const(0xB0)
 
 
 class SH1106:
-    def __init__(self, width, height, external_vcc):
+    def __init__(self, width, height, external_vcc, rotate90=False):
         self.width = width
         self.height = height
         self.external_vcc = external_vcc
+        self.rotate90 = rotate90
         self.pages = self.height // 8
-        self.buffer = bytearray(self.pages * self.width)
-        fb = framebuf.FrameBuffer(self.buffer, self.width, self.height,
-                                  framebuf.MVLSB)
-        self.framebuf = fb
-# set shortcuts for the methods of framebuf
+        self.bufsize = self.pages * self.width
+        self.renderbuf = bytearray(self.bufsize)
+        if rotate90:
+            self.displaybuf = bytearray(self.bufsize)
+            # HMSB is required to keep the bit order in the render buffer
+            # compatible with byte-for-byte remapping to the display buffer,
+            # which is in VLSB. Else we'd have to copy bit-by-bit!
+            fb = framebuf.FrameBuffer(self.renderbuf, self.height, self.width,
+                                      framebuf.MONO_HMSB)
+        else:
+            self.displaybuf = self.renderbuf
+            fb = framebuf.FrameBuffer(self.renderbuf, self.width, self.height,
+                                      framebuf.MONO_VLSB)
+
+        # flip() was called rotate() once, provide backwards compatibility.
+        self.rotate = self.flip
+
+        # set shortcuts for the methods of framebuf
         self.fill = fb.fill
         self.fill_rect = fb.fill_rect
         self.hline = fb.hline
@@ -114,7 +128,8 @@ class SH1106:
         self.reset()
         self.fill(0)
         self.poweron()
-        self.show()
+        # rotate90 requires a call to flip() for setting up.
+        self.flip(False)
 
     def poweroff(self):
         self.write_cmd(_SET_DISP | 0x00)
@@ -122,13 +137,11 @@ class SH1106:
     def poweron(self):
         self.write_cmd(_SET_DISP | 0x01)
 
-    def rotate(self, flag, update=True):
-        if flag:
-            self.write_cmd(_SET_SEG_REMAP | 0x01)  # mirror display vertically
-            self.write_cmd(_SET_SCAN_DIR | 0x08)  # mirror display hor.
-        else:
-            self.write_cmd(_SET_SEG_REMAP | 0x00)
-            self.write_cmd(_SET_SCAN_DIR | 0x00)
+    def flip(self, flag, update=True):
+        mir_v = flag ^ self.rotate90
+        mir_h = flag
+        self.write_cmd(_SET_SEG_REMAP | (0x01 if mir_v else 0x00))
+        self.write_cmd(_SET_SCAN_DIR | (0x08 if mir_h else 0x00))
         if update:
             self.show()
 
@@ -143,13 +156,17 @@ class SH1106:
         self.write_cmd(_SET_NORM_INV | (invert & 1))
 
     def show(self):
+        # self.* lookups in loops take significant time (~4fps).
+        (w, p, db, rb) = (self.width, self.pages,
+                          self.displaybuf, self.renderbuf)
+        if self.rotate90:
+            for i in range(self.bufsize):
+                db[w * (i % p) + (i // p)] = rb[i]
         for page in range(self.height // 8):
             self.write_cmd(_SET_PAGE_ADDRESS | page)
             self.write_cmd(_LOW_COLUMN_ADDRESS | 2)
             self.write_cmd(_HIGH_COLUMN_ADDRESS | 0)
-            self.write_data(self.buffer[
-                self.width * page:self.width * page + self.width
-            ])
+            self.write_data(db[(w*page):(w*page+w)])
 
     def reset(self, res):
         if res is not None:
@@ -163,14 +180,14 @@ class SH1106:
 
 class SH1106_I2C(SH1106):
     def __init__(self, width, height, i2c, res=None, addr=0x3c,
-                 external_vcc=False):
+                 rotate90=False, external_vcc=False):
         self.i2c = i2c
         self.addr = addr
         self.res = res
         self.temp = bytearray(2)
         if res is not None:
             res.init(res.OUT, value=1)
-        super().__init__(width, height, external_vcc)
+        super().__init__(width, height, external_vcc, rotate90)
 
     def write_cmd(self, cmd):
         self.temp[0] = 0x80  # Co=1, D/C#=0
@@ -186,7 +203,7 @@ class SH1106_I2C(SH1106):
 
 class SH1106_SPI(SH1106):
     def __init__(self, width, height, spi, dc, res=None, cs=None,
-                 external_vcc=False):
+                 rotate90=False, external_vcc=False):
         self.rate = 10 * 1000 * 1000
         dc.init(dc.OUT, value=0)
         if res is not None:
@@ -197,7 +214,7 @@ class SH1106_SPI(SH1106):
         self.dc = dc
         self.res = res
         self.cs = cs
-        super().__init__(width, height, external_vcc)
+        super().__init__(width, height, external_vcc, rotate90)
 
     def write_cmd(self, cmd):
         self.spi.init(baudrate=self.rate, polarity=0, phase=0)


### PR DESCRIPTION
Since the SH1106 has no hardware flag for doing this, we're doing it in software by creating a second buffer. One will be the user-facing one that receives all the render commands (`self.renderbuf`), while the other one will be constructed by remapping the bytes as required during `show()` (`self.displaybuf`). The second buffer will only be created when 90° rotation is enabled, because it essentially doubles the RAM required.

This renames the `rotate()` method to `flip()` in order to (hopefully) be less confusing. 90° rotation has to be enabled when constructing the instance, it cannot be toggled afterwards, because of the additional buffer required. For backwards compatibility, `rotate()` is still available as an alias to `flip()`.

The code has only been tested with a 128×64 display, because that's what's been available to me.