### PR TITLE
Update sh1106.py

### DIFF
--- a/sh1106.py
+++ b/sh1106.py
@@ -189,7 +189,7 @@ class SH1106(framebuf.FrameBuffer):
 
     def vline(self, x, y, h, color):
         super().vline(x, y, h, color)
-        self.register_updates(y, y+h)
+        self.register_updates(y, y+h-1)
 
     def fill(self, color):
         super().fill(color)
@@ -206,11 +206,11 @@ class SH1106(framebuf.FrameBuffer):
 
     def fill_rect(self, x, y, w, h, color):
         super().fill_rect(x, y, w, h, color)
-        self.register_updates(y, y+h)
+        self.register_updates(y, y+h-1)
 
     def rect(self, x, y, w, h, color):
         super().rect(x, y, w, h, color)
-        self.register_updates(y, y+h)
+        self.register_updates(y, y+h-1)
 
     def register_updates(self, y0, y1=None):
         # this function takes the top and optional bottom address of the changes made

--- a/sh1106.py
+++ b/sh1106.py
@@ -170,10 +170,13 @@ class SH1106(framebuf.FrameBuffer):
                 self.write_data(db[(w*page):(w*page+w)])
         self.pages_to_update = 0
 
-    def pixel(self, x, y, color):
-        super().pixel(x, y, color)
-        page = y // 8
-        self.pages_to_update |= 1 << page
+    def pixel(self, x, y, c=None):
+        if c is None:
+            return super().pixel(x, y)
+        else:
+            super().pixel(x, y , c)
+            page = y // 8
+            self.pages_to_update |= 1 << page
 
     def text(self, text, x, y, color=1):
         super().text(text, x, y, color)


### PR DESCRIPTION
This fork is intended to fix issue #25 by amending the y+h parameter of the methods vline, fill_rect and rect to y+h-1.