### PR TITLE
Update sh1106.py

### DIFF
--- a/sh1106.py
+++ b/sh1106.py
@@ -128,6 +128,7 @@ class SH1106(framebuf.FrameBuffer):
 
     def poweron(self):
         self.write_cmd(_SET_DISP | 0x01)
+        time.sleep_ms(100)
 
     def flip(self, flag=None, update=True):
         if flag is None:


### PR DESCRIPTION
This branch adds a 100 ms sleep to the `power_on()` method. This is recommended in the [SH1106 datasheet](https://www.pololu.com/file/0J1813/SH1106.pdf) (see page 32). It should reduce the risk of EIO interface errors.
I have not tested with this code or a SH1106 display, but I have implemented the change and tested it in my [SH1107](https://github.com/peter-l5/SH1107) derivative. 