### PR TITLE
During initialization show the erased screen instead of old, flipped data

### DIFF
--- a/sh1106.py
+++ b/sh1106.py
@@ -119,6 +119,7 @@ class SH1106(framebuf.FrameBuffer):
     def init_display(self):
         self.reset()
         self.fill(0)
+        self.show()
         self.poweron()
         # rotate90 requires a call to flip() for setting up.
         self.flip(self.flip_en)


### PR DESCRIPTION
Seems like we need this call to `show()` to give the `fill()` an actual effect.  Without that the display starts up with whatever data it had before, but possibly with the wrong flip, then 100ms later flips it correctly.