### PR TITLE
Fix typechecking

### DIFF
--- a/sh1106.py
+++ b/sh1106.py
@@ -99,6 +99,7 @@ class SH1106(framebuf.FrameBuffer):
         self.bufsize = self.pages * self.width
         self.renderbuf = bytearray(self.bufsize)
         self.pages_to_update = 0
+        self.delay = 0
 
         if self.rotate90:
             self.displaybuf = bytearray(self.bufsize)
@@ -115,6 +116,14 @@ class SH1106(framebuf.FrameBuffer):
         # flip() was called rotate() once, provide backwards compatibility.
         self.rotate = self.flip
         self.init_display()
+
+    # abstractmethod
+    def write_cmd(self, *args, **kwargs): 
+        raise NotImplementedError
+
+    # abstractmethod
+    def write_data(self,  *args, **kwargs):
+        raise NotImplementedError
 
     def init_display(self):
         self.reset()
@@ -230,7 +239,7 @@ class SH1106(framebuf.FrameBuffer):
         for page in range(start_page, end_page+1):
             self.pages_to_update |= 1 << page
 
-    def reset(self, res):
+    def reset(self, res=None):
         if res is not None:
             res(1)
             time.sleep_ms(1)
@@ -260,7 +269,7 @@ class SH1106_I2C(SH1106):
     def write_data(self, buf):
         self.i2c.writeto(self.addr, b'\x40'+buf)
 
-    def reset(self):
+    def reset(self,res=None):
         super().reset(self.res)
 
 
@@ -301,5 +310,5 @@ class SH1106_SPI(SH1106):
             self.dc(1)
             self.spi.write(buf)
 
-    def reset(self):
+    def reset(self, res=None):
         super().reset(self.res)

--- a/sh1106.pyi
+++ b/sh1106.pyi
@@ -41,7 +41,10 @@ For more details, visit the [SH1106 GitHub repository](https://github.com/robert
 """
 
 # sh1106.pyi - Stub file for SH1106 MicroPython library
-from typing import Optional
+from abc import abstractmethod
+from typing import Optional, overload
+
+from _typeshed import Incomplete
 from framebuf import FrameBuffer
 from machine import I2C, SPI, Pin
 
@@ -60,6 +63,12 @@ class SH1106(FrameBuffer):
         :param rotate: Rotation angle (0, 90, 180, 270 degrees).
         """
         ...
+
+    @abstractmethod
+    def write_cmd(self, *args, **kwargs) -> Incomplete: ...
+
+    @abstractmethod
+    def write_data(self,  *args, **kwargs) -> Incomplete: ...
 
     def init_display(self) -> None:
         """Initialize and reset the display."""
@@ -113,8 +122,18 @@ class SH1106(FrameBuffer):
         :param full_update: If True, update all pages; otherwise, update only modified pages.
         """
         ...
-
-    def pixel(self, x: int, y: int, color: Optional[int] = None) -> Optional[int]:
+    @overload
+    def pixel(self, x: int, y: int, /) -> int:
+        """
+        Get or set the color of a specific pixel.
+        
+        :param x: X-coordinate.
+        :param y: Y-coordinate.
+        :param color: Pixel color (0 or 1). If None, return the current color.
+        """
+        ...    
+    @overload
+    def pixel(self, x: int, y: int, color: int) -> None:
         """
         Get or set the color of a specific pixel.
         
@@ -175,7 +194,7 @@ class SH1106(FrameBuffer):
         """Draw an outlined rectangle."""
         ...
 
-    def reset(self, res: Optional[Pin]) -> None:
+    def reset(self, res: Optional[Pin]=None) -> None:
         """Reset the display using the reset pin."""
         ...
 
@@ -198,7 +217,7 @@ class SH1106_I2C(SH1106):
         """Write data to the display via I2C."""
         ...
 
-    def reset(self) -> None:
+    def reset(self, res: Optional[Pin]=None) -> None:
         """Reset the display via the reset pin (if available)."""
         ...
 
@@ -221,6 +240,6 @@ class SH1106_SPI(SH1106):
         """Write data to the display via SPI."""
         ...
 
-    def reset(self) -> None:
+    def reset(self, res: Optional[Pin]=None) -> None:
         """Reset the display via the reset pin (if available)."""
         ...


### PR DESCRIPTION
Hi Robert,

I bough a ESP_C3 board with a little display by mistake (needed an S2) , 
and found my way to this repo.

I was very pleasantly surprised that there is also a type stub provided 🤓.

When I match then with the recently released v1.24.1 stubs there are a few things that the type-checkers don't like.

this PR should solve these issues
- match the `pixel` methods with `Framebuffer` 
- match the `reset` methods of the classes 
- add write_cmd and write_data as "abstract methods to the base class 
- add delay 

As a bonus I found that I had incorrectly typed `Framebuffer.blit` in the micropython-stubs, so I brought that inline with this stub. Thanks for that.

<details><summary>Resolved typechecker warnings</summary>
<p>

```
.../c3_oled_042/src/sh1106.py
  .../c3_oled_042/src/sh1106.py:120:9 - error: Argument missing for parameter "res" (reportCallIssue)
  .../c3_oled_042/src/sh1106.py:128:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:131:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:132:17 - error: Cannot access attribute "delay" for class "SH1106*"
    Attribute "delay" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:133:32 - error: Cannot access attribute "delay" for class "SH1106*"
    Attribute "delay" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:140:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:141:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:147:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:150:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:151:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:154:14 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:170:22 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:171:22 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:172:22 - error: Cannot access attribute "write_cmd" for class "SH1106*"
    Attribute "write_cmd" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:173:22 - error: Cannot access attribute "write_data" for class "SH1106*"
    Attribute "write_data" is unknown (reportAttributeAccessIssue)
  .../c3_oled_042/src/sh1106.py:176:9 - error: Method "pixel" overrides class "FrameBuffer" in an incompatible manner
    Return type mismatch: base method returns type "int", override returns type "int | None"
      Type "int | None" is not assignable to type "int"
        "None" is not assignable to "int" (reportIncompatibleMethodOverride)
  .../c3_oled_042/src/sh1106.py:263:9 - error: Method "reset" overrides class "SH1106" in an incompatible manner
    Positional parameter count mismatch; base method has 2, but override has 1
    Parameter 2 mismatch: base parameter "res" is keyword parameter, override parameter is position-only (reportIncompatibleMethodOverride)
  .../c3_oled_042/src/sh1106.py:304:9 - error: Method "reset" overrides class "SH1106" in an incompatible manner
    Positional parameter count mismatch; base method has 2, but override has 1
    Parameter 2 mismatch: base parameter "res" is keyword parameter, override parameter is position-only (reportIncompatibleMethodOverride)
.../c3_oled_042/src/sh1106.pyi
  .../c3_oled_042/src/sh1106.pyi:117:9 - error: Method "pixel" overrides class "FrameBuffer" in an incompatible manner
    Return type mismatch: base method returns type "int", override returns type "int | None"
      Type "int | None" is not assignable to type "int"
        "None" is not assignable to "int" (reportIncompatibleMethodOverride)
  .../c3_oled_042/src/sh1106.pyi:154:9 - error: Method "blit" overrides class "FrameBuffer" in an incompatible manner
    Parameter 6 type mismatch: base parameter is type "FrameBuffer | None", override parameter is type "bytes | None"
      Type "FrameBuffer | None" is not assignable to type "bytes | None"
        Type "FrameBuffer" is not assignable to type "bytes | None"
          "FrameBuffer" is not assignable to "bytes"
          "FrameBuffer" is not assignable to "None" (reportIncompatibleMethodOverride)
  .../c3_oled_042/src/sh1106.pyi:201:9 - error: Method "reset" overrides class "SH1106" in an incompatible manner
    Positional parameter count mismatch; base method has 2, but override has 1
    Parameter 2 mismatch: base parameter "res" is keyword parameter, override parameter is position-only (reportIncompatibleMethodOverride)
  .../c3_oled_042/src/sh1106.pyi:224:9 - error: Method "reset" overrides class "SH1106" in an incompatible manner
    Positional parameter count mismatch; base method has 2, but override has 1
    Parameter 2 mismatch: base parameter "res" is keyword parameter, override parameter is position-only (reportIncompatibleMethodOverride)
22 errors, 0 warnings, 0 informations
-------------------------------------------------------------------------------------
mypy src
src/sh1106.pyi:117: error: Signature of "pixel" incompatible with supertype "FrameBuffer"  [override]
src/sh1106.pyi:117: note:      Superclass:
src/sh1106.pyi:117: note:          @overload
src/sh1106.pyi:117: note:          def pixel(self, int, int, /) -> int
src/sh1106.pyi:117: note:          @overload
src/sh1106.pyi:117: note:          def pixel(self, int, int, int, /) -> None
src/sh1106.pyi:117: note:      Subclass:
src/sh1106.pyi:117: note:          def pixel(self, x: int, y: int, color: int | None = ...) -> int | None
src/sh1106.pyi:154: error: Argument 5 of "blit" is incompatible with supertype "FrameBuffer"; supertype defines the argument type as "FrameBuffer | None"  [override]
src/sh1106.pyi:154: note: This violates the Liskov substitution principle
src/sh1106.pyi:154: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
src/sh1106.pyi:201: error: Signature of "reset" incompatible with supertype "SH1106"  [override]
src/sh1106.pyi:201: note:      Superclass:
src/sh1106.pyi:201: note:          def reset(self, res: Pin | None) -> None
src/sh1106.pyi:201: note:      Subclass:
src/sh1106.pyi:201: note:          def reset(self) -> None
src/sh1106.pyi:224: error: Signature of "reset" incompatible with supertype "SH1106"  [override]
src/sh1106.pyi:224: note:      Superclass:
src/sh1106.pyi:224: note:          def reset(self, res: Pin | None) -> None
src/sh1106.pyi:224: note:      Subclass:
src/sh1106.pyi:224: note:          def reset(self) -> None
Found 4 errors in 1 file (checked 2 source files)

```


</p>
</details> 


Signed-off-by: Jos Verlinde <Jos_Verlinde@hotmail.com>